### PR TITLE
Rb users

### DIFF
--- a/Tabloid-Fullstack/Controllers/CategoryController.cs
+++ b/Tabloid-Fullstack/Controllers/CategoryController.cs
@@ -58,6 +58,11 @@ namespace Tabloid_Fullstack.Controllers
         [HttpPut("{id}")]
         public IActionResult Put(int id, Category category)
         {
+            if (id != category.Id)
+            {
+                return BadRequest();
+            }
+
             var currentUser = GetCurrentUserProfile();
 
             if (currentUser.UserTypeId != UserType.ADMIN_ID)

--- a/Tabloid-Fullstack/Controllers/CategoryController.cs
+++ b/Tabloid-Fullstack/Controllers/CategoryController.cs
@@ -55,8 +55,8 @@ namespace Tabloid_Fullstack.Controllers
             return CreatedAtAction("Get", new { id = category.Id }, category);
         }
 
-        [HttpPut]
-        public IActionResult Put(Category category)
+        [HttpPut("{id}")]
+        public IActionResult Put(int id, Category category)
         {
             var currentUser = GetCurrentUserProfile();
 
@@ -69,7 +69,7 @@ namespace Tabloid_Fullstack.Controllers
             return NoContent();
         }
 
-        [HttpPut("{id}")]
+        [HttpDelete("{id}")]
         public IActionResult Delete(int id)
         {
             var currentUser = GetCurrentUserProfile();

--- a/Tabloid-Fullstack/Controllers/UserProfileController.cs
+++ b/Tabloid-Fullstack/Controllers/UserProfileController.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Tabloid_Fullstack.Models;
 using Tabloid_Fullstack.Repositories;
@@ -26,6 +27,20 @@ namespace Tabloid_Fullstack.Controllers
             return Ok(_repo.GetByFirebaseUserId(firebaseUserId));
         }
 
+        [HttpGet]
+        public IActionResult GetAll()
+        {
+            var currentUser = GetCurrentUserProfile();
+
+            if (currentUser.UserTypeId != UserType.ADMIN_ID)
+            {
+                return Unauthorized();
+            }
+
+            var users = _repo.GetAll();
+            return Ok(users);
+        }
+
         [HttpPost]
         public IActionResult Post(UserProfile userProfile)
         {
@@ -36,6 +51,12 @@ namespace Tabloid_Fullstack.Controllers
                 nameof(GetUserProfile),
                 new { firebaseUserId = userProfile.FirebaseUserId },
                 userProfile);
+        }
+
+        private UserProfile GetCurrentUserProfile()
+        {
+            var firebaseUserId = User.FindFirst(ClaimTypes.NameIdentifier).Value;
+            return _repo.GetByFirebaseUserId(firebaseUserId);
         }
     }
 }

--- a/Tabloid-Fullstack/Controllers/UserProfileController.cs
+++ b/Tabloid-Fullstack/Controllers/UserProfileController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,6 +14,7 @@ namespace Tabloid_Fullstack.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
+    [Authorize]
     public class UserProfileController : ControllerBase
     {
         private readonly IUserProfileRepository _repo;

--- a/Tabloid-Fullstack/Repositories/CategoryRepository.cs
+++ b/Tabloid-Fullstack/Repositories/CategoryRepository.cs
@@ -47,7 +47,7 @@ namespace Tabloid_Fullstack.Repositories
             {
                 return;
             }
-            _context.Entry(localCat).State = EntityState.Detached;
+
             _context.Entry(category).State = EntityState.Modified;
             _context.SaveChanges();
         }

--- a/Tabloid-Fullstack/Repositories/CategoryRepository.cs
+++ b/Tabloid-Fullstack/Repositories/CategoryRepository.cs
@@ -35,6 +35,19 @@ namespace Tabloid_Fullstack.Repositories
 
         public void Update(Category category)
         {
+            var localCat = _context.Set<Category>()
+                            .Local
+                            .FirstOrDefault(entry => entry.Id.Equals(category.Id));
+
+            if (localCat != null)
+            {
+                _context.Entry(localCat).State = EntityState.Detached;
+            }
+            else
+            {
+                return;
+            }
+            _context.Entry(localCat).State = EntityState.Detached;
             _context.Entry(category).State = EntityState.Modified;
             _context.SaveChanges();
         }

--- a/Tabloid-Fullstack/Repositories/CategoryRepository.cs
+++ b/Tabloid-Fullstack/Repositories/CategoryRepository.cs
@@ -35,19 +35,12 @@ namespace Tabloid_Fullstack.Repositories
 
         public void Update(Category category)
         {
-            var localCat = _context.Set<Category>()
-                            .Local
-                            .FirstOrDefault(entry => entry.Id.Equals(category.Id));
-
-            if (localCat != null)
-            {
-                _context.Entry(localCat).State = EntityState.Detached;
-            }
-            else
+            var originalCat = GetById(category.Id);
+            if (originalCat == null)
             {
                 return;
             }
-
+            _context.Entry(originalCat).State = EntityState.Detached;
             _context.Entry(category).State = EntityState.Modified;
             _context.SaveChanges();
         }

--- a/Tabloid-Fullstack/Repositories/CategoryRepository.cs
+++ b/Tabloid-Fullstack/Repositories/CategoryRepository.cs
@@ -42,6 +42,11 @@ namespace Tabloid_Fullstack.Repositories
         public void Delete(int id)
         {
             var category = GetById(id);
+            if (category == null)
+            {
+                return;
+            }
+
             category.IsActive = false;
             _context.Entry(category).State = EntityState.Modified;
             _context.SaveChanges();

--- a/Tabloid-Fullstack/Repositories/IUserProfileRepository.cs
+++ b/Tabloid-Fullstack/Repositories/IUserProfileRepository.cs
@@ -1,10 +1,12 @@
-﻿using Tabloid_Fullstack.Models;
+﻿using System.Collections.Generic;
+using Tabloid_Fullstack.Models;
 
 namespace Tabloid_Fullstack.Repositories
 {
     public interface IUserProfileRepository
     {
         void Add(UserProfile userProfile);
+        List<UserProfile> GetAll();
         UserProfile GetByFirebaseUserId(string firebaseUserId);
     }
 }

--- a/Tabloid-Fullstack/Repositories/UserProfileRepository.cs
+++ b/Tabloid-Fullstack/Repositories/UserProfileRepository.cs
@@ -27,6 +27,14 @@ namespace Tabloid_Fullstack.Repositories
 
         }
 
+        public List<UserProfile> GetAll()
+        {
+            return _context.UserProfile
+                .Include(up => up.UserType)
+                .OrderBy(u => u.DisplayName)
+                .ToList();
+        }
+
         public void Add(UserProfile userProfile)
         {
             _context.Add(userProfile);

--- a/Tabloid-Fullstack/client/src/components/AppHeader.js
+++ b/Tabloid-Fullstack/client/src/components/AppHeader.js
@@ -65,6 +65,11 @@ const AppHeader = () => {
                 {isAdmin() && (
                   <>
                     <NavItem>
+                      <NavLink to="/userprofiles" tag={Link}>
+                        User Profiles
+                      </NavLink>
+                    </NavItem>
+                    <NavItem>
                       <NavLink to="/categories" tag={Link}>
                         Categories
                       </NavLink>
@@ -81,19 +86,19 @@ const AppHeader = () => {
                 </NavItem>
               </>
             ) : (
-              <>
-                <NavItem>
-                  <NavLink to="/login" tag={Link}>
-                    Login
+                <>
+                  <NavItem>
+                    <NavLink to="/login" tag={Link}>
+                      Login
                   </NavLink>
-                </NavItem>
-                <NavItem>
-                  <NavLink to="/register" tag={Link}>
-                    Register
+                  </NavItem>
+                  <NavItem>
+                    <NavLink to="/register" tag={Link}>
+                      Register
                   </NavLink>
-                </NavItem>
-              </>
-            )}
+                  </NavItem>
+                </>
+              )}
           </Nav>
           {user ? (
             <NavbarText className="d-sm-none d-md-block">

--- a/Tabloid-Fullstack/client/src/components/ApplicationViews.js
+++ b/Tabloid-Fullstack/client/src/components/ApplicationViews.js
@@ -11,6 +11,7 @@ import { UserPost } from "../pages/UserPost";
 import { PostForm } from "../pages/PostForm";
 import { PostDelete } from "../pages/PostDelete";
 import TagList from "./TagList";
+import { ProfileManager } from "../pages/ProfileManager";
 
 const ApplicationViews = () => {
   const { isLoggedIn, isAdmin } = useContext(UserProfileContext);
@@ -27,15 +28,11 @@ const ApplicationViews = () => {
         {isLoggedIn ? <PostDetails /> : <Redirect to="/login" />}
       </Route>
       <Route path="/categories">
-        {isLoggedIn ? (
-          isAdmin() ? (
-            <CategoryManager />
-          ) : (
-            <Redirect to="/" />
-          )
-        ) : (
+        {isLoggedIn ?
+          (isAdmin() ? <CategoryManager /> : <Redirect to="/" />)
+          :
           <Redirect to="/login" />
-        )}
+        }
       </Route>
       <Route path="/comment/:postId">
         {isLoggedIn ? <CommentForm /> : <Redirect to="/login" />}
@@ -55,6 +52,14 @@ const ApplicationViews = () => {
         {isLoggedIn ? <PostDelete /> : <Redirect to="/login" />}
       </Route>
 
+      <Route path="/userprofiles">
+        {isLoggedIn ?
+          (isAdmin() ? <ProfileManager /> : <Redirect to="/" />)
+          :
+          <Redirect to="/login" />
+        }
+      </Route>
+
       <Route path="/login">
         <Login />
       </Route>
@@ -62,15 +67,11 @@ const ApplicationViews = () => {
         <Register />
       </Route>
       <Route path="/tags">
-        {isLoggedIn ? (
-          isAdmin() ? (
-            <TagList />
-          ) : (
-            <Redirect to="/" />
-          )
-        ) : (
+        {isLoggedIn ?
+          (isAdmin() ? <TagList /> : <Redirect to="/" />)
+          :
           <Redirect to="/login" />
-        )}
+        }
       </Route>
     </Switch>
   );

--- a/Tabloid-Fullstack/client/src/components/Category.js
+++ b/Tabloid-Fullstack/client/src/components/Category.js
@@ -31,21 +31,16 @@ const Category = ({ category, deleteCategory }) => {
 
   const updateCategory = () => {
     setIsEditing(true);
-    setUpdatedCategory({
-      id: category.id,
-      name: categoryEdits,
-      isActive: true
-    });
-    console.log(updatedCategory)
+    category.name = categoryEdits;
     getToken()
       .then((token) =>
-        fetch(`api/category/${updatedCategory.id}`, {
+        fetch(`api/category/${category.id}`, {
           method: "PUT",
           headers: {
             Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
-          body: JSON.stringify(updatedCategory),
+          body: JSON.stringify(category),
         })
       )
       .then(hideEditForm);

--- a/Tabloid-Fullstack/client/src/components/Category.js
+++ b/Tabloid-Fullstack/client/src/components/Category.js
@@ -33,7 +33,7 @@ const Category = ({ category, deleteCategory }) => {
     category.name = categoryEdits;
     getToken()
       .then((token) =>
-        fetch("api/category", {
+        fetch(`api/category/${category.id}`, {
           method: "PUT",
           headers: {
             Authorization: `Bearer ${token}`,

--- a/Tabloid-Fullstack/client/src/components/Category.js
+++ b/Tabloid-Fullstack/client/src/components/Category.js
@@ -17,6 +17,7 @@ const Category = ({ category, deleteCategory }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [pendingDelete, setPendingDelete] = useState(false);
   const [categoryEdits, setCategoryEdits] = useState("");
+  const [updatedCategory, setUpdatedCategory] = useState({});
 
   const showEditForm = () => {
     setIsEditing(true);
@@ -30,16 +31,21 @@ const Category = ({ category, deleteCategory }) => {
 
   const updateCategory = () => {
     setIsEditing(true);
-    category.name = categoryEdits;
+    setUpdatedCategory({
+      id: category.id,
+      name: categoryEdits,
+      isActive: true
+    });
+    console.log(updatedCategory)
     getToken()
       .then((token) =>
-        fetch(`api/category/${category.id}`, {
+        fetch(`api/category/${updatedCategory.id}`, {
           method: "PUT",
           headers: {
             Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
-          body: JSON.stringify(category),
+          body: JSON.stringify(updatedCategory),
         })
       )
       .then(hideEditForm);

--- a/Tabloid-Fullstack/client/src/components/Category.js
+++ b/Tabloid-Fullstack/client/src/components/Category.js
@@ -59,6 +59,7 @@ const Category = ({ category, deleteCategory }) => {
               size="sm"
               onChange={(e) => setCategoryEdits(e.target.value)}
               value={categoryEdits}
+              maxLength="50"
             />
             <ButtonGroup size="sm">
               <Button onClick={updateCategory}>Save</Button>
@@ -69,21 +70,21 @@ const Category = ({ category, deleteCategory }) => {
           </InputGroup>
         </Form>
       ) : (
-        <>
-          <div className="p-1">{category.name}</div>
-          <ButtonGroup size="sm">
-            <Button className="btn btn-primary" onClick={showEditForm}>
-              Edit
+          <>
+            <div className="p-1">{category.name}</div>
+            <ButtonGroup size="sm">
+              <Button className="btn btn-primary" onClick={showEditForm}>
+                Edit
             </Button>
-            <Button
-              className="btn btn-danger"
-              onClick={(e) => setPendingDelete(true)}
-            >
-              Delete
+              <Button
+                className="btn btn-danger"
+                onClick={(e) => setPendingDelete(true)}
+              >
+                Delete
             </Button>
-          </ButtonGroup>
-        </>
-      )}
+            </ButtonGroup>
+          </>
+        )}
       {/* DELETE CONFIRM MODAL */}
       <Modal isOpen={pendingDelete}>
         <ModalHeader>Delete {category.name}?</ModalHeader>

--- a/Tabloid-Fullstack/client/src/components/UserProfile.js
+++ b/Tabloid-Fullstack/client/src/components/UserProfile.js
@@ -1,7 +1,11 @@
 export const UserProfile = ({ profile }) => {
     return (
         <div className="justify-content-between align-items-center row">
-            <img className="pl-2" src={profile.imageLocation} />
+            <img className="pl-2 sm"
+                src={profile.imageLocation}
+                style={{ width: '5em' }}
+                alt={`${profile.displayName} profile picture`}
+            />
             <div>{`${profile.firstName} ${profile.lastName}`}</div>
             <div>{profile.displayName}</div>
             <div className="pr-2">{profile.userTypeId === 1 ? "Admin" : "Author"}</div>

--- a/Tabloid-Fullstack/client/src/components/UserProfile.js
+++ b/Tabloid-Fullstack/client/src/components/UserProfile.js
@@ -1,0 +1,38 @@
+export const UserProfile = ({ profile }) => {
+    return (
+        <table className="table">
+            {/* <thead>
+                <tr>
+                    <th>
+                        {profile.imageLocation}
+                    </th>
+                    <th>
+                        {`${profile.firstName} ${profile.lastName}`}
+                    </th>
+                    <th>
+                        {profile.displayName}
+                    </th>
+                    <th>
+                        {profile.userType}
+                    </th>
+                </tr>
+            </thead> */}
+            <tbody>
+                <tr>
+                    <td>
+                        {profile.imageLocation}
+                    </td>
+                    <td>
+                        {`${profile.firstName} ${profile.lastName}`}
+                    </td>
+                    <td>
+                        {profile.displayName}
+                    </td>
+                    <td>
+                        {profile.userTypeId === 1 ? "Admin" : "Author"}
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    );
+}

--- a/Tabloid-Fullstack/client/src/components/UserProfile.js
+++ b/Tabloid-Fullstack/client/src/components/UserProfile.js
@@ -1,38 +1,10 @@
 export const UserProfile = ({ profile }) => {
     return (
-        <table className="table">
-            {/* <thead>
-                <tr>
-                    <th>
-                        {profile.imageLocation}
-                    </th>
-                    <th>
-                        {`${profile.firstName} ${profile.lastName}`}
-                    </th>
-                    <th>
-                        {profile.displayName}
-                    </th>
-                    <th>
-                        {profile.userType}
-                    </th>
-                </tr>
-            </thead> */}
-            <tbody>
-                <tr>
-                    <td>
-                        {profile.imageLocation}
-                    </td>
-                    <td>
-                        {`${profile.firstName} ${profile.lastName}`}
-                    </td>
-                    <td>
-                        {profile.displayName}
-                    </td>
-                    <td>
-                        {profile.userTypeId === 1 ? "Admin" : "Author"}
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+        <div className="justify-content-between align-items-center row">
+            <img className="pl-2" src={profile.imageLocation} />
+            <div>{`${profile.firstName} ${profile.lastName}`}</div>
+            <div>{profile.displayName}</div>
+            <div className="pr-2">{profile.userTypeId === 1 ? "Admin" : "Author"}</div>
+        </div>
     );
 }

--- a/Tabloid-Fullstack/client/src/pages/CategoryManager.js
+++ b/Tabloid-Fullstack/client/src/pages/CategoryManager.js
@@ -87,6 +87,7 @@ const CategoryManager = () => {
                 onChange={(e) => setNewCategory(e.target.value)}
                 value={newCategory}
                 placeholder="Add a new category"
+                maxLength="50"
               />
               <Button onClick={saveNewCategory}>Save</Button>
             </InputGroup>

--- a/Tabloid-Fullstack/client/src/pages/CategoryManager.js
+++ b/Tabloid-Fullstack/client/src/pages/CategoryManager.js
@@ -55,7 +55,7 @@ const CategoryManager = () => {
   const deleteCategory = (id) => {
     getToken().then((token) =>
       fetch(`/api/category/${id}`, {
-        method: "PUT",
+        method: "DELETE",
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/Tabloid-Fullstack/client/src/pages/ProfileManager.js
+++ b/Tabloid-Fullstack/client/src/pages/ProfileManager.js
@@ -30,7 +30,7 @@ export const ProfileManager = () => {
         <div className="container mt-5">
             <h1>User Profiles</h1>
             <div className="row justify-content-center">
-                <div className="col-xs-12 col-sm-8 col-md-6">
+                <div className="col col col col">
                     <ListGroup>
                         {userProfiles.map(profile => (
                             <ListGroupItem key={profile.id}>

--- a/Tabloid-Fullstack/client/src/pages/ProfileManager.js
+++ b/Tabloid-Fullstack/client/src/pages/ProfileManager.js
@@ -27,7 +27,7 @@ export const ProfileManager = () => {
     };
 
     return (
-        <div className="container mt-5">
+        <div className="container my-5">
             <h1>User Profiles</h1>
             <div className="row justify-content-center">
                 <div className="col col col col">

--- a/Tabloid-Fullstack/client/src/pages/ProfileManager.js
+++ b/Tabloid-Fullstack/client/src/pages/ProfileManager.js
@@ -1,3 +1,45 @@
+import { useState, useContext, useEffect } from "react";
+import { UserProfileContext } from "../providers/UserProfileProvider";
+import { ListGroup, ListGroupItem } from "reactstrap";
+import { UserProfile } from "../components/UserProfile";
+
 export const ProfileManager = () => {
-    return null;
+    const { getToken } = useContext(UserProfileContext);
+    const [userProfiles, setUserProfiles] = useState([]);
+
+    useEffect(() => {
+        getUserProfiles();
+    }, []);
+
+    const getUserProfiles = () => {
+        getToken().then((token) =>
+            fetch("/api/userprofile", {
+                method: "GET",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            })
+                .then((res) => res.json())
+                .then((profiles) => {
+                    setUserProfiles(profiles);
+                })
+        );
+    };
+
+    return (
+        <div className="container mt-5">
+            <h1>User Profiles</h1>
+            <div className="row justify-content-center">
+                <div className="col-xs-12 col-sm-8 col-md-6">
+                    <ListGroup>
+                        {userProfiles.map(profile => (
+                            <ListGroupItem key={profile.id}>
+                                <UserProfile profile={profile} />
+                            </ListGroupItem>
+                        ))}
+                    </ListGroup>
+                </div>
+            </div>
+        </div>
+    );
 }

--- a/Tabloid-Fullstack/client/src/pages/ProfileManager.js
+++ b/Tabloid-Fullstack/client/src/pages/ProfileManager.js
@@ -1,0 +1,3 @@
+export const ProfileManager = () => {
+    return null;
+}


### PR DESCRIPTION
[26](https://github.com/nss-day-cohort-43-csharp/Fullstack-Rage-Against-The-Virtual-Machine/issues/26)

Allows admin user to have access to a list of all users and their user types

Testing:
- Ensure the only way to get to '/userprofiles' route is when logged in as an admin user
- When logged in as an admin user, navigate to the User Profiles page
- There you should see a list of all users, displaying their profile pic, name, display name, and user type
- The names should be alphabetized by display name
- Above routing restrictions should apply to the backend as well