### PR TITLE
Ep reactions & read time

### DIFF
--- a/Tabloid-Fullstack/Controllers/PostController.cs
+++ b/Tabloid-Fullstack/Controllers/PostController.cs
@@ -122,5 +122,14 @@ namespace Tabloid_Fullstack.Controllers
             var firebaseUserId = User.FindFirst(ClaimTypes.NameIdentifier).Value;
             return _userRepo.GetByFirebaseUserId(firebaseUserId);
         }
+
+
+        [HttpPost("addreaction")]
+        public IActionResult AddReaction(PostReaction postReaction)
+        {
+            postReaction.UserProfileId = GetCurrentUserProfile().Id;
+            _repo.AddReaction(postReaction);
+            return CreatedAtAction("Get", new { id = postReaction.Id }, postReaction);
+        }
     }
 }

--- a/Tabloid-Fullstack/Controllers/PostController.cs
+++ b/Tabloid-Fullstack/Controllers/PostController.cs
@@ -145,7 +145,8 @@ namespace Tabloid_Fullstack.Controllers
             postReaction.UserProfileId = GetCurrentUserProfile().Id;
             _repo.AddReaction(postReaction);
             return CreatedAtAction("Get", new { id = postReaction.Id }, postReaction);
-            } catch (Exception)
+            } 
+            catch (Exception)
             {
                 return NotFound();
             }

--- a/Tabloid-Fullstack/Controllers/PostController.cs
+++ b/Tabloid-Fullstack/Controllers/PostController.cs
@@ -140,9 +140,15 @@ namespace Tabloid_Fullstack.Controllers
         [HttpPost("addreaction")]
         public IActionResult AddReaction(PostReaction postReaction)
         {
+            try
+            {
             postReaction.UserProfileId = GetCurrentUserProfile().Id;
             _repo.AddReaction(postReaction);
             return CreatedAtAction("Get", new { id = postReaction.Id }, postReaction);
+            } catch (Exception)
+            {
+                return NotFound();
+            }
         }
     }
 }

--- a/Tabloid-Fullstack/Models/PostReaction.cs
+++ b/Tabloid-Fullstack/Models/PostReaction.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,5 +13,8 @@ namespace Tabloid_Fullstack.Models
         public Post Post { get; set; }
         public int ReactionId { get; set; }
         public Reaction Reaction { get; set; }
+        public int UserProfileId { get; set; }
+
+
     }
 }

--- a/Tabloid-Fullstack/Models/ViewModels/PostDetails.cs
+++ b/Tabloid-Fullstack/Models/ViewModels/PostDetails.cs
@@ -9,6 +9,7 @@ namespace Tabloid_Fullstack.Models.ViewModels
     {
         public Post Post { get; set; }
         public List<ReactionCount> ReactionCounts { get; set; }
+        public List<PostReaction> PostReactions { get; set; }
 
         public List<Comment> Comments { get; set; }
     }

--- a/Tabloid-Fullstack/Models/ViewModels/PostSummary.cs
+++ b/Tabloid-Fullstack/Models/ViewModels/PostSummary.cs
@@ -19,5 +19,18 @@ namespace Tabloid_Fullstack.Models.ViewModels
         public DateTime? PublishDateTime { get; set; }
         public string PreviewText => AbbreviatedText + "...";
         public Category Category { get; set; }
+
+        public string Content { get; set; }
+        public double ReadTime
+        {
+            get
+            {
+                var wordCount = Content.Split(' ').Length;
+                double time = wordCount / 150;
+                double mins = Math.Ceiling(time);
+
+                return mins;
+            }
+        }
     }
 }

--- a/Tabloid-Fullstack/Models/ViewModels/PostSummary.cs
+++ b/Tabloid-Fullstack/Models/ViewModels/PostSummary.cs
@@ -25,9 +25,8 @@ namespace Tabloid_Fullstack.Models.ViewModels
         {
             get
             {
-                var wordCount = Content.Split(' ').Length;
-                double time = wordCount / 150;
-                double mins = Math.Ceiling(time);
+                double wordCount = Content.Split(' ').Length;
+                double mins = Math.Ceiling(wordCount / 150);
 
                 return mins;
             }

--- a/Tabloid-Fullstack/Repositories/IPostRepository.cs
+++ b/Tabloid-Fullstack/Repositories/IPostRepository.cs
@@ -13,5 +13,8 @@ namespace Tabloid_Fullstack.Repositories
         List<PostSummary> GetByUserId(int id);
         List<ReactionCount> GetReactionCounts(int postId);
         void Update(Post post);
+
+        void AddReaction(PostReaction postReaction);
+        List<PostReaction> GetPostReactionsByPost(int postId);
     }
 }

--- a/Tabloid-Fullstack/Repositories/PostRepository.cs
+++ b/Tabloid-Fullstack/Repositories/PostRepository.cs
@@ -35,7 +35,8 @@ namespace Tabloid_Fullstack.Repositories
                     AuthorName = p.UserProfile.DisplayName,
                     AbbreviatedText = p.Content.Substring(0, 200),
                     PublishDateTime = p.PublishDateTime,
-                    Category = p.Category
+                    Category = p.Category,
+                    Content = p.Content
                 })
                 .ToList();
         }
@@ -65,7 +66,8 @@ namespace Tabloid_Fullstack.Repositories
                 AuthorName = p.UserProfile.DisplayName,
                 AbbreviatedText = p.Content.Substring(0, 200),
                 PublishDateTime = p.PublishDateTime,
-                Category = p.Category
+                Category = p.Category,
+                Content = p.Content
             })
             .ToList();
         }

--- a/Tabloid-Fullstack/Repositories/PostRepository.cs
+++ b/Tabloid-Fullstack/Repositories/PostRepository.cs
@@ -113,5 +113,17 @@ namespace Tabloid_Fullstack.Repositories
             _context.Post.RemoveRange(postToDelete);
             _context.SaveChanges();
         }
+
+        public List<PostReaction> GetPostReactionsByPost(int postId)
+        {
+            return _context.PostReaction
+                .Where(pr => pr.PostId == postId)
+                .ToList();
+        }
+        public void AddReaction(PostReaction postReaction)
+        {
+            _context.Add(postReaction);
+            _context.SaveChanges();
+        }
     }
 }

--- a/Tabloid-Fullstack/client/src/components/PostReactions.js
+++ b/Tabloid-Fullstack/client/src/components/PostReactions.js
@@ -30,23 +30,11 @@ const PostReactions = ({ postReactions, getPost }) => {
       .then(() => getPost());
   };
 
-  // useEffect(() => {
-  //   if(postReactions) {
-  //     return getToken().then((token) => {
-  //       fetch(`/api/reaction/${postReactions.ReactionId}`, {
-  //         method: "GET",
-  //         headers: {
-  //           Authorization: `Bearer ${token}`
-  //         }
-  //       }) . then ( res => res.json())
-  //       .then(data => {
-  //         setHasReacted(false)
-  //       })
-  //     })
-  //   } else {
-  //     setHasReacted(false)
-  //   }
-  // }, []);
+  useEffect(() => {
+    if(postReactions) {
+      return;
+    }
+  }, []);
 
   return (
     <div className="float-left">

--- a/Tabloid-Fullstack/client/src/components/PostReactions.js
+++ b/Tabloid-Fullstack/client/src/components/PostReactions.js
@@ -1,16 +1,49 @@
-import React from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { Badge } from "reactstrap";
+import { useParams } from "react-router-dom";
 import "./PostReaction.css";
+import { UserProfileContext } from "../providers/UserProfileProvider";
 
-const PostReactions = ({ postReactions }) => {
+const PostReactions = ({ postReactions, getPost }) => {
+  const { getCurrentUser, getToken } = useContext(UserProfileContext);
+  const [hasReacted, setHasReacted] = useState(false);
+  const { postId } = useParams();
+  const user = getCurrentUser();
+
+  const addReaction = (e) => {
+    let postReactionObj = {
+      postId,
+      userProfileId: user.id,
+      ReactionId: e.target.id,
+    };
+    return getToken()
+      .then((token) => {
+        fetch("/api/post/addreaction", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(postReactionObj),
+        });
+      })
+      .then(() => getPost());
+  };
+
+  useEffect(() => {
+    // if(postReactions)
+  }, []);
+
   return (
     <div className="float-left">
       {postReactions.map((postReaction) => (
         <div key={postReaction.reaction.id} className="d-inline-block mx-2">
           <Badge
             pill
+            id={postReaction.reaction.id}
             className="p-2 border border-dark post-reaction__pill"
             title={postReaction.reaction.name}
+            onClick={addReaction}
           >
             {postReaction.reaction.emoji} {postReaction.count}
           </Badge>

--- a/Tabloid-Fullstack/client/src/components/PostReactions.js
+++ b/Tabloid-Fullstack/client/src/components/PostReactions.js
@@ -30,9 +30,23 @@ const PostReactions = ({ postReactions, getPost }) => {
       .then(() => getPost());
   };
 
-  useEffect(() => {
-    // if(postReactions)
-  }, []);
+  // useEffect(() => {
+  //   if(postReactions) {
+  //     return getToken().then((token) => {
+  //       fetch(`/api/reaction/${postReactions.ReactionId}`, {
+  //         method: "GET",
+  //         headers: {
+  //           Authorization: `Bearer ${token}`
+  //         }
+  //       }) . then ( res => res.json())
+  //       .then(data => {
+  //         setHasReacted(false)
+  //       })
+  //     })
+  //   } else {
+  //     setHasReacted(false)
+  //   }
+  // }, []);
 
   return (
     <div className="float-left">

--- a/Tabloid-Fullstack/client/src/components/PostSummaryCard.js
+++ b/Tabloid-Fullstack/client/src/components/PostSummaryCard.js
@@ -32,6 +32,9 @@ const PostSummaryCard = ({ post }) => {
           <p className="ml-5">
             Published on {formatDate(post.publishDateTime)}
           </p>
+          <p className="ml-5">
+            {post.readTime} min read
+          </p>
         </div>
       </div>
     </Card>

--- a/Tabloid-Fullstack/client/src/pages/PostDetails.js
+++ b/Tabloid-Fullstack/client/src/pages/PostDetails.js
@@ -101,7 +101,7 @@ const PostDetails = () => {
         </div>
         <div className="text-justify post-details__content">{post.content}</div>
         <div className="my-4">
-          <PostReactions postReactions={reactionCounts} />
+          <PostReactions postReactions={reactionCounts} getPost={getPost}/>
         </div>
         <div>
           {post.userProfileId === currentUser ? (


### PR DESCRIPTION
- read time should display on the "explore" page for each post summary card
- user should be able to react to a post by clicking reaction on the post details page. 
- additional clicks on a reaction should increase the total for that particular reaction. 

compleates issue #35 & #45  (issue #36 was complete in boilerplate code)
